### PR TITLE
Update createUpdateCollections.ejs

### DIFF
--- a/views/forestay/createUpdateCollections.ejs
+++ b/views/forestay/createUpdateCollections.ejs
@@ -4,21 +4,36 @@
     <% if (_.get(forestay.config.attributes[attrKey], ["meta","forestay","createUpdateUi"]) === 'tagging') { %>
       <% include createUpdateCollectionsTagging.ejs %>
     <% } else { // end createUpdateUi Type%>
-      <% forestay.config.attributes[attrKey].availableValues.forEach(function(av){ %>
-        <div>
+      <% 
+      cpt=0;
+      forestay.config.attributes[attrKey].availableValues.forEach(function(av){ %>
+        
           <%
             var selected = "";
           %>
           <%
             if(forestay.id){
               forestay.config.attributes[attrKey].selectedValues.forEach(function(sv){
-                if(sv.id == av.id) selected = "checked"
+                if(sv.id == av.id && forestay.config.attributes[attrKey].meta.forestay.displayAs!=="select") selected = "checked";
+                if(sv.id == av.id && forestay.config.attributes[attrKey].meta.forestay.displayAs==="select") selected = "selected";
               })
             }
           %>
+           <%
+            if(forestay.config.attributes[attrKey].meta.forestay.displayAs!=="select"){
+            %>
+            <div>
           <input type="checkbox" name="<%= attrKey %>[]" value="<%= av.id %>" <%= selected %>>
           <label for="<%= attrKey %>[]"><%= av[forestay.config.attributes[attrKey].meta.forestay.populateBy] %></label>
-        </div>
-        <% }) %>
+           </div>
+          <% } else {
+          
+          if(cpt++==0) {%> <select multiple name="<%= attrKey %>[]"> <% } %> 
+         <option value="<%= av.id %>" <%= selected %>> <%= av[forestay.config.attributes[attrKey].meta.forestay.populateBy] %></option>
+          <% } %> 
+       
+        <% })
+
+ if(forestay.config.attributes[attrKey].meta.forestay.displayAs=="select"){%> </select>  <% }%>
     <% }%>
 <% } /* end else popualteBy !=string */ %>


### PR DESCRIPTION
Adds the possibility to display dependent model as a multiple dropdown menu rather than checkboxes
just fill 'displayAs' in the model as "select" or "checkbox"
example :

```javascript
 tile: {
      collection: 'Tile',
      via: 'rituel_id',
      meta: {
      forestay:{
        displayAs:'select',
        populateBy: "name"       
      }
  }
```
